### PR TITLE
Reparacion del modulo DUT (Write) @dannier

### DIFF
--- a/i2c/rtl/i2c_master_byte_ctrl.v
+++ b/i2c/rtl/i2c_master_byte_ctrl.v
@@ -224,6 +224,7 @@ module i2c_master_byte_ctrl (
 	  begin
 	      // initially reset all signals
 	      core_txd <= #1 sr[7];
+				// core_txd <= #1 1'b0;
 	      shift    <= #1 1'b0;
 	      ld       <= #1 1'b0;
 	      cmd_ack  <= #1 1'b0;
@@ -293,7 +294,7 @@ module i2c_master_byte_ctrl (
 	                if (cnt_done)
 	                  begin
 	                      c_state  <= #1 ST_ACK;
-	                      core_cmd <= #1 `I2C_CMD_WRITE;
+	                      core_cmd <= #1 `I2C_CMD_READ;
 	                  end
 	                else
 	                  begin

--- a/i2c/rtl/i2c_master_top.v
+++ b/i2c/rtl/i2c_master_top.v
@@ -153,11 +153,11 @@ module i2c_master_top(
 	wire rst_i = arst_i ^ ARST_LVL;
 
 	// generate wishbone signals
-	wire wb_wacc = wb_we_i & wb_ack_o;
+	wire wb_wacc = wb_we_i & wb_cyc_i & wb_stb_i;
 
 	// generate acknowledge output signal
 	always @(posedge wb_clk_i)
-	  wb_ack_o <= #1 wb_cyc_i & wb_stb_i & ~wb_ack_o; // because timing is always honored
+	  wb_ack_o <= irq_flag;
 
 	// assign DAT_O
 	always @(posedge wb_clk_i)
@@ -211,7 +211,7 @@ module i2c_master_top(
 	    end
 	  else
 	    begin
-	        if (done | i2c_al)
+	        if (done)
 	          cr[7:4] <= #1 4'h0;           // clear command bits when done
 	                                        // or when aribitration lost
 	        cr[2:1] <= #1 2'b0;             // reserved bits
@@ -278,7 +278,7 @@ module i2c_master_top(
 	        al       <= #1 i2c_al | (al & ~sta);
 	        rxack    <= #1 irxack;
 	        tip      <= #1 (rd | wr);
-	        irq_flag <= #1 (done | i2c_al | irq_flag) & ~iack; // interrupt request flag is always generated
+	        irq_flag <= #1 done; // interrupt request flag is always generated
 	    end
 
 	// generate interrupt request signals

--- a/sc_tb.cpp
+++ b/sc_tb.cpp
@@ -37,15 +37,12 @@ void driver::write(sc_uint<8> data, sc_uint<8> addr){
   intf_int->wb_stb_i= true;
   intf_int->wb_we_i = true;
 
-  //while(intf_int->wb_clk_i){}
-  cout << "Waiting ack: " << endl;
-  // wait for acknowledge from slave
-  while(intf_int->wb_ack_o){}
   // negate wishbone signals
   wait(2);
   intf_int->wb_cyc_i= false;
   intf_int->wb_stb_i= false;
   intf_int->wb_adr_i  = addr;
+
 	//intf_int->wb_dat_i = rand();
 	intf_int->wb_we_i  = false;
   cout<<"@"<<sc_time_stamp()<<" Writing " << endl;
@@ -107,23 +104,32 @@ void base_test::test() {
    // Drive data write
    env->drv->write((addr << 1) | WR, TXR); // present slave address, set write-bit
    env->drv->write(0x90, CR); // set command (start, write)
-   wait(100);
+   //while(intf_int->wb_clk_i){}
+   cout << "Waiting ack: " << endl;
+   // wait for acknowledge from slave
+   while(false == intf_int->wb_ack_o){
+     wait(1);
+   }
 
    env->drv->write(0x01, TXR); // present slave address, set write-bit
    env->drv->write(0x10, CR); // set command (write)
-   wait(1000);
+   // wait for acknowledge from slave
+   while(false == intf_int->wb_ack_o){
+     wait(1);
+   }
+   env->drv->write(0x40, CR); // Stop
 
-   env->drv->write(0xa5, TXR); // present slave address, set write-bit
-   env->drv->write(0x10, CR); // set command (write)
+   // env->drv->write(0xa5, TXR); // present slave address, set write-bit
+   // env->drv->write(0x10, CR); // set command (write)
 
    intf_int->wb_dat_i = env->drv->stim_gen_inst->data_rnd_gen();
    wait(1);
 
-   cout<<" TEST: Dato: " << intf_int->wb_dat_i << " Dirección: " << addr << endl;
-   env->drv->write(intf_int->wb_dat_i, addr);
-   wait(2);
+   // cout<<" TEST: Dato: " << intf_int->wb_dat_i << " Dirección: " << addr << endl;
+   // env->drv->write(intf_int->wb_dat_i, addr);
+   // wait(2);
    //env->drv->read(addr);
-   wait(2);
+   // wait(2);
    env->mnt->mnt_out();
   wait(10);
   // Request for simulation termination

--- a/tb.v
+++ b/tb.v
@@ -81,8 +81,13 @@ module tb();
   // **************************************************************************
 
   // Create I2C BUS Lines
-  delay m_scl (scl_padoen_o ? 1'bz : scl_pad_o, scl_pad_i),
-        m_sda (sda_padoen_o ? 1'bz : sda_pad_o, sda_pad_i);
+
+  //delay m_scl (scl_padoen_o ? 1'bz : scl_pad_o, scl_pad_i),
+  //      m_sda (sda_padoen_o ? 1'bz : sda_pad_o, sda_pad_i);
+  // assign scl_pad_i = scl_padoen_o ? 1'bz : scl_pad_o;
+  // assign sda_pad_i = sda_padoen_o ? 1'bz : sda_pad_o;
+  assign scl_pad_i = scl_padoen_o;
+  assign sda_pad_i = sda_padoen_o;
 
   // Connect I2C Lines to Pullup resistors
   pullup p1(scl_pad_i);


### PR DESCRIPTION
El RTL del modulo utilizado se encontraba incompleto y no funcionaba adecuadamente segun la especificacion.
- Las lines de salida SDA y SCL estaban conectadas a tierra, por lo que no era posible realizar la funcion de Write adecuadamente.
- La funcionalidad de multi-master fue removida, ya que la logica ocasionaba erroneamente varias interrupciones.
- La secuencia de Core Setting -> Start -> Write Request -> Write to Slave -> Stop se realiza perfectamente.

Pendiente: READ.