### PR TITLE
Modificacion minima para siempre imprimir status final del test

### DIFF
--- a/sc_tb.cpp
+++ b/sc_tb.cpp
@@ -83,8 +83,9 @@ void monitor::mnt_out(){
   bool failed_test;
   // num_free = scb_int->expected_fifo.num_free();
   //  cout << "fifo size: " << num_free << endl;
-  cout<<"@"<<sc_time_stamp()<<" entered scoreboard!" << endl;
+  cout<<"@"<<sc_time_stamp()<<" SCOREBOARD INFORMATION : " << endl;
   num_available= scb_int->expected_fifo.num_available();
+  if (num_available == 0) failed_test = true;
   for (sc_uint<8> j = 0; j < num_available ; j ++){
   data_out_read = scb_int->received_fifo.read();;
   data_out_exp  =  scb_int->expected_fifo.read();

--- a/test/multislave.cpp
+++ b/test/multislave.cpp
@@ -34,8 +34,9 @@ void suite_test::two_slave() {
 
   if((addr != 2) && ((sc_uint<8>) intf_int->wb_dat_o & ack_mask)){
     cout << "========================================" << endl;
-    cout << "ERROR CATCHED: Slave addr is not present" << endl;
+    cout << "ERROR CATCHED: Slave addr " << addr << " is not present" << endl;
     cout << "========================================" << endl;
+    env->mnt->mnt_out();
     return;
   }
   /* Store value in expected fifo */
@@ -81,8 +82,9 @@ void suite_test::two_slave() {
 
  if((addr != 2) && ((sc_uint<8>) intf_int->wb_dat_o & ack_mask)){
    cout << "========================================" << endl;
-   cout << "ERROR CATCHED: Slave addr is not present" << endl;
+   cout << "ERROR CATCHED: Slave addr " << addr << " is not present" << endl;
    cout << "========================================" << endl;
+   env->mnt->mnt_out();
    return;
  }
  /* Store value in expected fifo */

--- a/test/random_values.cpp
+++ b/test/random_values.cpp
@@ -30,9 +30,10 @@ void suite_test::random_addr() {
    env->drv->read(SR);
 
    if((addr != 2) && ((sc_uint<8>) intf_int->wb_dat_o & ack_mask)){
-     cout << "========================================" << endl;
-     cout << "ERROR CATCHED: Slave addr is not present" << endl;
-     cout << "========================================" << endl;
+     cout << "=====================================================" << endl;
+     cout << "ERROR CATCHED: Slave addr " << addr << " is not present" << endl;
+     cout << "=====================================================" << endl;
+      env->mnt->mnt_out();
      return;
    }
    /* Store value in expected fifo */
@@ -161,8 +162,9 @@ void suite_test::random_all() {
 
    if((addr != 2) && ((sc_uint<8>) intf_int->wb_dat_o & ack_mask)){
      cout << "========================================" << endl;
-     cout << "ERROR CATCHED: Slave addr is not present" << endl;
+     cout << "ERROR CATCHED: Slave addr " << addr << " is not present" << endl;
      cout << "========================================" << endl;
+     env->mnt->mnt_out();
      return;
    }
    /* Store value in expected fifo */


### PR DESCRIPTION
Lo unico que agregué fue en los tests de random slave address, si se detecta la condicion de fallo, que igual se entre en el scoreboard para mostrar que el test falló. El unico test al que no consideré necesario fue al de reset